### PR TITLE
Milestone 1: Core logic tests (reducer + utilities)

### DIFF
--- a/src/context/app/appReducer.test.js
+++ b/src/context/app/appReducer.test.js
@@ -1,0 +1,226 @@
+import appReducer from './appReducer';
+import {
+  GET_RESULT_VIDEOS,
+  SET_SELECTED_VIDEO,
+  LOAD_PLAYER_SUCCESS,
+  LOAD_PLAYER_ERROR,
+  SET_LOADING,
+  TOGGLE_THEME,
+  ACTIVATE_LOGIN,
+  DEACTIVATE_LOGIN,
+  SIGN_UP_USER,
+  LOG_IN_USER,
+  LOG_OUT_USER,
+  ADD_FAVORITE,
+  REMOVE_FAVORITE,
+} from '../types';
+import {
+  resultVideos,
+  relatedVideos,
+  selectedVideo,
+  currentUser,
+  currentFavorites,
+} from '../../utils/testMocks';
+
+const baseState = {
+  searchText: 'wizeline',
+  resultVideos: [],
+  relatedVideos: [],
+  selectedVideo: {},
+  currentUser: {},
+  currentFavorites: [],
+  loading: false,
+  shouldShowLogin: false,
+  theme: 'light',
+};
+
+describe('appReducer', () => {
+  it('returns current state for unknown action', () => {
+    const state = appReducer(baseState, { type: 'UNKNOWN' });
+    expect(state).toBe(baseState);
+  });
+
+  describe('GET_RESULT_VIDEOS', () => {
+    it('sets resultVideos, searchText, and loading to false', () => {
+      const state = appReducer(
+        { ...baseState, loading: true },
+        {
+          type: GET_RESULT_VIDEOS,
+          payload: { resultVideos, query: 'react' },
+        },
+      );
+      expect(state.searchText).toBe('react');
+      expect(state.resultVideos).toHaveLength(resultVideos.length);
+      expect(state.loading).toBe(false);
+    });
+
+    it('merges favorites into result videos', () => {
+      const state = appReducer(
+        { ...baseState, currentFavorites },
+        {
+          type: GET_RESULT_VIDEOS,
+          payload: { resultVideos, query: 'wizeline' },
+        },
+      );
+      const matched = state.resultVideos.find(
+        (v) => v.id === currentFavorites[0].id,
+      );
+      expect(matched.isFavorite).toBe(true);
+    });
+  });
+
+  describe('SET_SELECTED_VIDEO', () => {
+    it('sets selectedVideo', () => {
+      const state = appReducer(baseState, {
+        type: SET_SELECTED_VIDEO,
+        payload: selectedVideo,
+      });
+      expect(state.selectedVideo).toBe(selectedVideo);
+    });
+  });
+
+  describe('LOAD_PLAYER_SUCCESS', () => {
+    it('sets selectedVideo, videos, favorites, and loading to false', () => {
+      const updatedLocalFavorites = {
+        results: resultVideos,
+        related: relatedVideos,
+        favorites: currentFavorites,
+      };
+      const state = appReducer(
+        { ...baseState, loading: true },
+        {
+          type: LOAD_PLAYER_SUCCESS,
+          payload: { selectedVideo, updatedLocalFavorites },
+        },
+      );
+      expect(state.selectedVideo).toBe(selectedVideo);
+      expect(state.resultVideos).toBe(resultVideos);
+      expect(state.relatedVideos).toBe(relatedVideos);
+      expect(state.currentFavorites).toBe(currentFavorites);
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  describe('LOAD_PLAYER_ERROR', () => {
+    it('sets relatedVideos and loading to false', () => {
+      const updatedLocalFavorites = { related: relatedVideos };
+      const state = appReducer(
+        { ...baseState, loading: true },
+        {
+          type: LOAD_PLAYER_ERROR,
+          payload: { updatedLocalFavorites },
+        },
+      );
+      expect(state.relatedVideos).toBe(relatedVideos);
+      expect(state.loading).toBe(false);
+    });
+  });
+
+  describe('SET_LOADING', () => {
+    it('sets loading to true', () => {
+      const state = appReducer(baseState, { type: SET_LOADING });
+      expect(state.loading).toBe(true);
+    });
+  });
+
+  describe('TOGGLE_THEME', () => {
+    it('sets theme to payload value', () => {
+      const state = appReducer(baseState, {
+        type: TOGGLE_THEME,
+        payload: 'dark',
+      });
+      expect(state.theme).toBe('dark');
+    });
+  });
+
+  describe('ACTIVATE_LOGIN', () => {
+    it('sets shouldShowLogin to true', () => {
+      const state = appReducer(baseState, { type: ACTIVATE_LOGIN });
+      expect(state.shouldShowLogin).toBe(true);
+    });
+  });
+
+  describe('DEACTIVATE_LOGIN', () => {
+    it('sets shouldShowLogin to false', () => {
+      const state = appReducer(
+        { ...baseState, shouldShowLogin: true },
+        { type: DEACTIVATE_LOGIN },
+      );
+      expect(state.shouldShowLogin).toBe(false);
+    });
+  });
+
+  describe('SIGN_UP_USER', () => {
+    it('sets currentUser and resets currentFavorites', () => {
+      const state = appReducer(
+        { ...baseState, currentFavorites },
+        { type: SIGN_UP_USER, payload: currentUser },
+      );
+      expect(state.currentUser).toBe(currentUser);
+      expect(state.currentFavorites).toEqual([]);
+    });
+  });
+
+  describe('LOG_IN_USER', () => {
+    it('sets currentUser and merges favorites into videos', () => {
+      const updatedLocalFavorites = {
+        results: resultVideos,
+        related: relatedVideos,
+        favorites: currentFavorites,
+      };
+      const state = appReducer(baseState, {
+        type: LOG_IN_USER,
+        payload: { user: currentUser, updatedLocalFavorites },
+      });
+      expect(state.currentUser).toBe(currentUser);
+      expect(state.resultVideos).toBe(resultVideos);
+      expect(state.relatedVideos).toBe(relatedVideos);
+      expect(state.currentFavorites).toBe(currentFavorites);
+    });
+  });
+
+  describe('LOG_OUT_USER', () => {
+    it('clears currentUser and currentFavorites', () => {
+      const state = appReducer(
+        { ...baseState, currentUser, currentFavorites },
+        { type: LOG_OUT_USER },
+      );
+      expect(state.currentUser).toEqual({});
+      expect(state.currentFavorites).toEqual([]);
+    });
+  });
+
+  describe('ADD_FAVORITE', () => {
+    it('updates resultVideos, relatedVideos, and currentFavorites', () => {
+      const payload = {
+        results: resultVideos,
+        related: relatedVideos,
+        favorites: currentFavorites,
+      };
+      const state = appReducer(baseState, {
+        type: ADD_FAVORITE,
+        payload,
+      });
+      expect(state.resultVideos).toBe(resultVideos);
+      expect(state.relatedVideos).toBe(relatedVideos);
+      expect(state.currentFavorites).toBe(currentFavorites);
+    });
+  });
+
+  describe('REMOVE_FAVORITE', () => {
+    it('updates resultVideos, relatedVideos, and currentFavorites', () => {
+      const payload = {
+        results: resultVideos,
+        related: relatedVideos,
+        favorites: [],
+      };
+      const state = appReducer(
+        { ...baseState, currentFavorites },
+        { type: REMOVE_FAVORITE, payload },
+      );
+      expect(state.resultVideos).toBe(resultVideos);
+      expect(state.relatedVideos).toBe(relatedVideos);
+      expect(state.currentFavorites).toEqual([]);
+    });
+  });
+});

--- a/src/utils/updateLocalFavorites.test.js
+++ b/src/utils/updateLocalFavorites.test.js
@@ -1,0 +1,77 @@
+import updateLocalFavorites from './updateLocalFavorites';
+
+const makeVideo = (id, isFavorite = null) => ({
+  id,
+  title: `Video ${id}`,
+  isFavorite,
+});
+
+const makeFavorite = (id) => ({
+  id,
+  title: `Video ${id}`,
+  isFavorite: true,
+});
+
+describe('updateLocalFavorites', () => {
+  it('returns results, related, and favorites keys', () => {
+    const result = updateLocalFavorites([], [], []);
+    expect(result).toHaveProperty('results');
+    expect(result).toHaveProperty('related');
+    expect(result).toHaveProperty('favorites');
+  });
+
+  it('passes through videos unchanged when there are no favorites', () => {
+    const results = [makeVideo('a'), makeVideo('b')];
+    const related = [makeVideo('c')];
+    const output = updateLocalFavorites(results, related, []);
+    expect(output.results).toEqual(results);
+    expect(output.related).toEqual(related);
+    expect(output.favorites).toEqual([]);
+  });
+
+  it('marks matching videos as isFavorite when favorites overlap', () => {
+    const results = [makeVideo('a'), makeVideo('b')];
+    const related = [makeVideo('c')];
+    const favorites = [makeFavorite('a'), makeFavorite('c')];
+
+    const output = updateLocalFavorites(results, related, favorites);
+    expect(output.results.find((v) => v.id === 'a').isFavorite).toBe(true);
+    expect(output.results.find((v) => v.id === 'b').isFavorite).toBeNull();
+    expect(output.related.find((v) => v.id === 'c').isFavorite).toBe(true);
+  });
+
+  it('unfavorites videos that were previously marked but no longer in favorites', () => {
+    const results = [makeVideo('a', true), makeVideo('b', true)];
+    const related = [];
+    const favorites = [makeFavorite('a')];
+
+    const output = updateLocalFavorites(results, related, favorites);
+    expect(output.results.find((v) => v.id === 'a').isFavorite).toBe(true);
+    expect(output.results.find((v) => v.id === 'b').isFavorite).toBe(false);
+  });
+
+  it('handles empty result and related arrays', () => {
+    const favorites = [makeFavorite('a')];
+    const output = updateLocalFavorites([], [], favorites);
+    expect(output.results).toEqual([]);
+    expect(output.related).toEqual([]);
+    expect(output.favorites).toEqual(favorites);
+  });
+
+  it('handles favorites that do not match any video', () => {
+    const results = [makeVideo('a')];
+    const favorites = [makeFavorite('z')];
+    const output = updateLocalFavorites(results, [], favorites);
+    expect(output.results.find((v) => v.id === 'a').isFavorite).toBeNull();
+  });
+
+  it('marks all matching videos when all results are favorites', () => {
+    const results = [makeVideo('a'), makeVideo('b')];
+    const favorites = [makeFavorite('a'), makeFavorite('b')];
+
+    const output = updateLocalFavorites(results, [], favorites);
+    output.results.forEach((v) => {
+      expect(v.isFavorite).toBe(true);
+    });
+  });
+});

--- a/src/utils/validateItems.test.js
+++ b/src/utils/validateItems.test.js
@@ -1,0 +1,85 @@
+import validateItems from './validateItems';
+
+const makeItem = (overrides = {}) => ({
+  id: { videoId: 'abc123' },
+  snippet: {
+    title: 'Test Video',
+    description: 'A description',
+    channelTitle: 'Test Channel',
+    thumbnails: { medium: { url: 'https://img.youtube.com/test.jpg' } },
+  },
+  ...overrides,
+});
+
+describe('validateItems', () => {
+  it('transforms valid API items into internal video format', () => {
+    const items = [makeItem()];
+    const result = validateItems(items);
+    expect(result).toEqual([
+      {
+        id: 'abc123',
+        title: 'Test Video',
+        description: 'A description',
+        channelTitle: 'Test Channel',
+        thumbnail: 'https://img.youtube.com/test.jpg',
+        isFavorite: null,
+      },
+    ]);
+  });
+
+  it('filters out items missing snippet', () => {
+    const items = [makeItem(), { id: { videoId: 'no-snippet' } }];
+    const result = validateItems(items);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('abc123');
+  });
+
+  it('filters out items missing id.videoId', () => {
+    const items = [makeItem(), { id: {}, snippet: makeItem().snippet }];
+    const result = validateItems(items);
+    expect(result).toHaveLength(1);
+  });
+
+  it('filters out items with no id at all', () => {
+    const items = [makeItem(), { snippet: makeItem().snippet }];
+    const result = validateItems(items);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(validateItems([])).toEqual([]);
+  });
+
+  it('decodes HTML entities in title, description, and channelTitle', () => {
+    const items = [
+      makeItem({
+        snippet: {
+          title: 'Rock &amp; Roll &#34;Live&#34;',
+          description: 'It&#39;s a &quot;great&quot; show',
+          channelTitle: 'Tom &amp; Jerry&#39;s &apos;Channel&apos;',
+          thumbnails: { medium: { url: 'https://img.youtube.com/test.jpg' } },
+        },
+      }),
+    ];
+    const result = validateItems(items);
+    expect(result[0].title).toBe('Rock & Roll "Live"');
+    expect(result[0].description).toBe('It\'s a "great" show');
+    expect(result[0].channelTitle).toBe("Tom & Jerry's 'Channel'");
+  });
+
+  it('limits results to 24 items', () => {
+    const items = Array.from({ length: 30 }, (_, i) =>
+      makeItem({ id: { videoId: `vid-${i}` } }),
+    );
+    const result = validateItems(items);
+    expect(result).toHaveLength(24);
+  });
+
+  it('sets isFavorite to null for all items', () => {
+    const items = [makeItem(), makeItem({ id: { videoId: 'xyz' } })];
+    const result = validateItems(items);
+    result.forEach((item) => {
+      expect(item.isFavorite).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **appReducer tests** (15 tests): All 13 action types + default case, including favorite merge behavior in GET_RESULT_VIDEOS
- **validateItems tests** (8 tests): API item filtering, HTML entity decoding (`&amp;`, `&#34;`, `&#39;`, `&quot;`, `&apos;`), 24-item limit, edge cases
- **updateLocalFavorites tests** (7 tests): No favorites, partial/full overlap, removed favorites, non-matching favorites, empty arrays

Brings test count from **49 → 79** with 100% coverage on all three modules.

## Test plan
- [x] All 79 tests pass (`npm run test:coverage`)
- [x] Coverage thresholds met (branches up from 58% to 68%)
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)