### PR TITLE
Milestone 3: Component interaction tests

### DIFF
--- a/src/components/Header/_children/NavControls.test.jsx
+++ b/src/components/Header/_children/NavControls.test.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen, act, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import AppContext from '../../../context/app/appContext';
+import AlertContext from '../../../context/alert/alertContext';
+import { lightTheme } from '../../../context/app/themes';
+import NavControls from './NavControls';
+
+const logOutUser = vi.fn();
+const activateLogin = vi.fn();
+const toggleTheme = vi.fn();
+
+const renderComponent = ({ isLoggedIn = false } = {}) => {
+  const currentUser = isLoggedIn
+    ? { id: 'uid-1', email: 'test@test.com', isLoggedIn: true }
+    : {};
+
+  return render(
+    <AlertContext.Provider value={{ alert: null, setAlert: vi.fn() }}>
+      <AppContext.Provider
+        value={{
+          currentUser,
+          logOutUser,
+          activateLogin,
+          toggleTheme,
+          theme: 'light',
+        }}
+      >
+        <MemoryRouter>
+          <ThemeProvider theme={lightTheme}>
+            <NavControls />
+          </ThemeProvider>
+        </MemoryRouter>
+      </AppContext.Provider>
+    </AlertContext.Provider>,
+  );
+};
+
+// The dropdown is portaled to document.body as a direct child div.
+// "Theme" text only appears in the dropdown, so we use it as an anchor.
+const getDropdown = () => screen.getByText('Theme').closest('div[class]').parentElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('NavControls', () => {
+  describe('hamburger toggle', () => {
+    it('opens dropdown when hamburger is clicked', async () => {
+      renderComponent();
+      await userEvent.click(screen.getByLabelText('Menu'));
+
+      expect(screen.getByText('Theme')).toBeInTheDocument();
+    });
+
+    it('closes dropdown when hamburger is clicked again', async () => {
+      renderComponent();
+      const hamburger = screen.getByLabelText('Menu');
+
+      await userEvent.click(hamburger);
+      expect(screen.getByText('Theme')).toBeInTheDocument();
+
+      await userEvent.click(hamburger);
+      act(() => vi.advanceTimersByTime(250));
+
+      expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('dropdown items by auth state', () => {
+    it('shows "Sign up" and no Favorites link when logged out', async () => {
+      renderComponent({ isLoggedIn: false });
+      await userEvent.click(screen.getByLabelText('Menu'));
+
+      const dropdown = getDropdown();
+      expect(within(dropdown).getByText('Sign up')).toBeInTheDocument();
+      expect(within(dropdown).queryByText('Favorites')).not.toBeInTheDocument();
+    });
+
+    it('shows "Log out" and Favorites link when logged in', async () => {
+      renderComponent({ isLoggedIn: true });
+      await userEvent.click(screen.getByLabelText('Menu'));
+
+      const dropdown = getDropdown();
+      expect(within(dropdown).getByText('Log out')).toBeInTheDocument();
+      expect(within(dropdown).getByText('Favorites')).toBeInTheDocument();
+    });
+  });
+
+  describe('close behaviors', () => {
+    it('closes dropdown on backdrop click', async () => {
+      renderComponent();
+      await userEvent.click(screen.getByLabelText('Menu'));
+      expect(screen.getByText('Theme')).toBeInTheDocument();
+
+      // Backdrop is the portaled sibling before the dropdown
+      const dropdown = getDropdown();
+      const backdrop = dropdown.previousElementSibling;
+      await userEvent.click(backdrop);
+      act(() => vi.advanceTimersByTime(250));
+
+      expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+    });
+
+    it('closes dropdown when Favorites link is clicked', async () => {
+      renderComponent({ isLoggedIn: true });
+      await userEvent.click(screen.getByLabelText('Menu'));
+
+      const dropdown = getDropdown();
+      await userEvent.click(within(dropdown).getByText('Favorites'));
+      act(() => vi.advanceTimersByTime(250));
+
+      expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+    });
+
+    it('calls logOutUser and closes when "Log out" is clicked', async () => {
+      renderComponent({ isLoggedIn: true });
+      await userEvent.click(screen.getByLabelText('Menu'));
+
+      const dropdown = getDropdown();
+      await userEvent.click(within(dropdown).getByText('Log out'));
+      act(() => vi.advanceTimersByTime(250));
+
+      expect(logOutUser).toHaveBeenCalled();
+      expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+    });
+
+    it('calls activateLogin and closes when "Sign up" is clicked', async () => {
+      renderComponent({ isLoggedIn: false });
+      await userEvent.click(screen.getByLabelText('Menu'));
+
+      const dropdown = getDropdown();
+      await userEvent.click(within(dropdown).getByText('Sign up'));
+      act(() => vi.advanceTimersByTime(250));
+
+      expect(activateLogin).toHaveBeenCalled();
+      expect(screen.queryByText('Theme')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/VideoItem/VideoItem.navigation.test.jsx
+++ b/src/components/VideoItem/VideoItem.navigation.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AppContext from '../../context/app/appContext';
+import { currentUser, selectedVideo } from '../../utils/testMocks';
+import VideoItem from './VideoItem';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: mockPathname }),
+}));
+
+let mockPathname = '/';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPathname = '/';
+  window.scrollTo = vi.fn();
+});
+
+const renderComponent = () =>
+  render(
+    <AppContext.Provider
+      value={{ currentUser, setSelectedVideo: vi.fn() }}
+    >
+      <VideoItem video={selectedVideo} />
+    </AppContext.Provider>,
+  );
+
+describe('VideoItem navigation', () => {
+  it('navigates to /player/:id when on home page', async () => {
+    mockPathname = '/';
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('videoItem'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/player/${selectedVideo.id}`,
+    );
+  });
+
+  it('navigates to /player/:id when on player page', async () => {
+    mockPathname = '/player/some-other-id';
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('videoItem'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/player/${selectedVideo.id}`,
+    );
+  });
+
+  it('navigates to /favorites/player/:id when on favorites page', async () => {
+    mockPathname = '/favorites';
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('videoItem'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/favorites/player/${selectedVideo.id}`,
+    );
+  });
+
+  it('navigates to /favorites/player/:id when on favorites player page', async () => {
+    mockPathname = '/favorites/player/some-other-id';
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('videoItem'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/favorites/player/${selectedVideo.id}`,
+    );
+  });
+});

--- a/src/components/pages/PlayerView.lifecycle.test.jsx
+++ b/src/components/pages/PlayerView.lifecycle.test.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AppContext from '../../context/app/appContext';
+import { currentUser, selectedVideo, relatedVideos } from '../../utils/testMocks';
+
+// Must declare mock before imports that use it
+let mockVideoId = selectedVideo.id;
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/player' }),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ videoId: mockVideoId }),
+}));
+
+// Import after mock setup
+import PlayerView from './PlayerView';
+import FavoritesPlayer from './FavoritesPlayer';
+
+describe('PlayerView lifecycle', () => {
+  const loadPlayerById = vi.fn();
+
+  const renderPlayerView = (contextOverrides = {}) =>
+    render(
+      <AppContext.Provider
+        value={{
+          currentUser,
+          selectedVideo,
+          relatedVideos,
+          currentFavorites: [],
+          loading: false,
+          loadPlayerById,
+          ...contextOverrides,
+        }}
+      >
+        <PlayerView />
+      </AppContext.Provider>,
+    );
+
+  const renderFavoritesPlayer = (contextOverrides = {}) =>
+    render(
+      <AppContext.Provider
+        value={{
+          currentUser,
+          selectedVideo,
+          currentFavorites: [selectedVideo],
+          loading: false,
+          loadPlayerById,
+          ...contextOverrides,
+        }}
+      >
+        <FavoritesPlayer />
+      </AppContext.Provider>,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVideoId = selectedVideo.id;
+  });
+
+  it('calls loadPlayerById with includeRelated: true on PlayerView mount', () => {
+    renderPlayerView();
+    expect(loadPlayerById).toHaveBeenCalledWith({
+      videoId: selectedVideo.id,
+      includeRelated: true,
+    });
+  });
+
+  it('calls loadPlayerById with includeRelated: false on FavoritesPlayer mount', () => {
+    renderFavoritesPlayer();
+    expect(loadPlayerById).toHaveBeenCalledWith({
+      videoId: selectedVideo.id,
+      includeRelated: false,
+    });
+  });
+
+  it('re-calls loadPlayerById when videoId param changes on PlayerView', () => {
+    const { rerender } = renderPlayerView();
+    expect(loadPlayerById).toHaveBeenCalledTimes(1);
+
+    mockVideoId = 'new-video-id';
+    rerender(
+      <AppContext.Provider
+        value={{
+          currentUser,
+          selectedVideo,
+          relatedVideos,
+          currentFavorites: [],
+          loading: false,
+          loadPlayerById,
+        }}
+      >
+        <PlayerView />
+      </AppContext.Provider>,
+    );
+
+    expect(loadPlayerById).toHaveBeenCalledTimes(2);
+    expect(loadPlayerById).toHaveBeenLastCalledWith({
+      videoId: 'new-video-id',
+      includeRelated: true,
+    });
+  });
+
+  it('re-calls loadPlayerById when videoId param changes on FavoritesPlayer', () => {
+    const { rerender } = renderFavoritesPlayer();
+    expect(loadPlayerById).toHaveBeenCalledTimes(1);
+
+    mockVideoId = 'new-video-id';
+    rerender(
+      <AppContext.Provider
+        value={{
+          currentUser,
+          selectedVideo,
+          currentFavorites: [selectedVideo],
+          loading: false,
+          loadPlayerById,
+        }}
+      >
+        <FavoritesPlayer />
+      </AppContext.Provider>,
+    );
+
+    expect(loadPlayerById).toHaveBeenCalledTimes(2);
+    expect(loadPlayerById).toHaveBeenLastCalledWith({
+      videoId: 'new-video-id',
+      includeRelated: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **NavControls** (8 tests): Hamburger toggle open/close, dropdown items by auth state (Sign up vs Log out, Favorites link visibility), close behaviors (backdrop click, Favorites link, Log out button, Sign up button)
- **Player view lifecycle** (4 tests): `loadPlayerById` called on mount with correct `includeRelated` flag (`true` for PlayerView, `false` for FavoritesPlayer), re-called when `videoId` param changes
- **VideoItem navigation** (4 tests): Navigates to `/player/:id` from home/player pages, `/favorites/player/:id` from favorites pages

Brings test count from **99 → 115**. `NavControls.jsx` now at 100% coverage, branches up from 62% to 81%.

## Test plan
- [x] All 115 tests pass (`npm run test:coverage`)
- [x] Coverage thresholds met (branches at 81%)
- [x] Lint clean (zero warnings)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)