### PR TITLE
Fix videos disappearing after auth state resolves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Workflow
 
-Always create a new branch off `master` before starting work on any new feature or fix.
+Always create a new branch off `master` before starting work on any new feature or fix. Never commit directly to `master` — all changes must go through a pull request.
 
 When changing or adding code, review existing tests for affected modules and update or add tests to maintain coverage. New features need new tests. Bug fixes need a test that would have caught the bug. Refactors must keep existing tests passing. Run `npm run test:coverage` to verify coverage thresholds (80%) are still met.
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ netlify dev
 ```bash
 npm test             # watch mode
 npm run test:run     # single run
-npm run test:coverage
+npm run test:coverage # coverage report with 80% threshold enforcement
 ```
+
+The test suite includes 140+ tests covering components, state management, utilities, routing, and Netlify functions. Coverage thresholds (80% statements, branches, functions, and lines) are enforced in CI — PRs that drop below will fail.
 
 ---
 
 ## Deployment
 
-The app is deployed on Netlify with continuous deployment from the `master` branch. Environment variables are configured in the Netlify project settings. The `netlify.toml` configures the build command, publish directory, and a catch-all redirect for client-side routing.
+The app is deployed on Netlify with continuous deployment from the `master` branch. A GitHub Actions CI pipeline runs lint, tests with coverage, and build on every pull request. Environment variables are configured in the Netlify project settings. The `netlify.toml` configures the build command, publish directory, and a catch-all redirect for client-side routing.

--- a/src/context/app/AppState.jsx
+++ b/src/context/app/AppState.jsx
@@ -58,8 +58,7 @@ const AppState = ({ children }) => {
           isLoggedIn: true,
         };
         const favorites = await getFavorites(user.id);
-        const updatedLocalFavorites = updateLocalFavorites([], [], favorites);
-        dispatch({ type: LOG_IN_USER, payload: { user, updatedLocalFavorites } });
+        dispatch({ type: LOG_IN_USER, payload: { user, favorites } });
       }
       setAuthResolved(true);
     });
@@ -177,11 +176,7 @@ const AppState = ({ children }) => {
   // LOG IN USER
   const logInUser = async (email, password) => {
     let user = {};
-    let updatedLocalFavorites = {
-      results: state.resultVideos,
-      related: state.relatedVideos,
-      favorites: state.currentFavorites,
-    };
+    let favorites = state.currentFavorites;
     try {
       const userCredential = await signInWithEmailAndPassword(
         auth,
@@ -193,12 +188,7 @@ const AppState = ({ children }) => {
         email: userCredential.user.email,
         isLoggedIn: true,
       };
-      const favorites = await getFavorites(user.id);
-      updatedLocalFavorites = updateLocalFavorites(
-        state.resultVideos,
-        state.relatedVideos,
-        favorites,
-      );
+      favorites = await getFavorites(user.id);
       deactivateLogin();
       setAlert(`You've successfully logged in as ${user.email}`);
     } catch (error) {
@@ -207,7 +197,7 @@ const AppState = ({ children }) => {
 
     dispatch({
       type: LOG_IN_USER,
-      payload: { user, updatedLocalFavorites },
+      payload: { user, favorites },
     });
   };
 

--- a/src/context/app/AppState.test.jsx
+++ b/src/context/app/AppState.test.jsx
@@ -467,6 +467,31 @@ describe('AppState action creators', () => {
       expect(screen.getByTestId('authResolved')).toHaveTextContent('true');
     });
 
+    it('does not wipe resultVideos when auth resolves after search', async () => {
+      const apiItems = [makeApiItem('vid1'), makeApiItem('vid2')];
+      youtubeSearch.mockResolvedValue({ items: apiItems });
+      getFavorites.mockResolvedValue(currentFavorites);
+
+      const { contextRef } = renderWithContext();
+
+      // Search loads videos first
+      await act(async () => {
+        await contextRef.current.getResultVideos('wizeline');
+      });
+      expect(screen.getByTestId('resultCount')).toHaveTextContent('2');
+
+      // Then auth resolves with a logged-in user
+      await act(async () =>
+        authCallback({ uid: 'uid-abc', email: 'auto@test.com' }),
+      );
+
+      // Videos should still be there
+      expect(screen.getByTestId('resultCount')).toHaveTextContent('2');
+      expect(screen.getByTestId('currentUser')).toHaveTextContent(
+        'auto@test.com',
+      );
+    });
+
     it('sets authResolved without setting user when no user', async () => {
       renderWithContext();
 

--- a/src/context/app/appReducer.js
+++ b/src/context/app/appReducer.js
@@ -77,14 +77,20 @@ export default (state, action) => {
         currentUser: action.payload,
         currentFavorites: [],
       };
-    case LOG_IN_USER:
+    case LOG_IN_USER: {
+      const merged = updateLocalFavorites(
+        state.resultVideos,
+        state.relatedVideos,
+        action.payload.favorites,
+      );
       return {
         ...state,
         currentUser: action.payload.user,
-        resultVideos: action.payload.updatedLocalFavorites.results,
-        relatedVideos: action.payload.updatedLocalFavorites.related,
-        currentFavorites: action.payload.updatedLocalFavorites.favorites,
+        resultVideos: merged.results,
+        relatedVideos: merged.related,
+        currentFavorites: merged.favorites,
       };
+    }
     case LOG_OUT_USER:
       return {
         ...state,

--- a/src/context/app/appReducer.test.js
+++ b/src/context/app/appReducer.test.js
@@ -162,20 +162,37 @@ describe('appReducer', () => {
   });
 
   describe('LOG_IN_USER', () => {
-    it('sets currentUser and merges favorites into videos', () => {
-      const updatedLocalFavorites = {
-        results: resultVideos,
-        related: relatedVideos,
-        favorites: currentFavorites,
+    it('sets currentUser and merges favorites with existing videos', () => {
+      const stateWithVideos = {
+        ...baseState,
+        resultVideos,
+        relatedVideos,
       };
-      const state = appReducer(baseState, {
+      const state = appReducer(stateWithVideos, {
         type: LOG_IN_USER,
-        payload: { user: currentUser, updatedLocalFavorites },
+        payload: { user: currentUser, favorites: currentFavorites },
       });
       expect(state.currentUser).toBe(currentUser);
-      expect(state.resultVideos).toBe(resultVideos);
-      expect(state.relatedVideos).toBe(relatedVideos);
-      expect(state.currentFavorites).toBe(currentFavorites);
+      expect(state.currentFavorites).toEqual(currentFavorites);
+      // Videos that match favorites should be marked
+      const matched = state.resultVideos.find(
+        (v) => v.id === currentFavorites[0].id,
+      );
+      expect(matched.isFavorite).toBe(true);
+    });
+
+    it('preserves existing videos when logging in', () => {
+      const stateWithVideos = {
+        ...baseState,
+        resultVideos,
+        relatedVideos,
+      };
+      const state = appReducer(stateWithVideos, {
+        type: LOG_IN_USER,
+        payload: { user: currentUser, favorites: [] },
+      });
+      expect(state.resultVideos).toHaveLength(resultVideos.length);
+      expect(state.relatedVideos).toHaveLength(relatedVideos.length);
     });
   });
 


### PR DESCRIPTION
## Summary
- **Bug**: On first load, fetched videos would flash briefly then disappear. The `onAuthStateChanged` callback was calling `updateLocalFavorites([], [], favorites)` with empty arrays, so when `LOG_IN_USER` dispatched after videos had loaded, the reducer overwrote `resultVideos` with empty merged results.
- **Fix**: Moved `updateLocalFavorites` into the `LOG_IN_USER` reducer case where it has access to the current `state.resultVideos` and `state.relatedVideos`. Both `onAuthStateChanged` and `logInUser` now pass raw `favorites` instead of pre-merged results.
- **Regression test**: Added test that loads videos via search, then triggers auth, and verifies videos are preserved.

Also includes:
- Update README with test coverage and CI pipeline info
- Add "no direct commits to master" rule to CLAUDE.md workflow

## Test plan
- [x] All 142 tests pass (`npm run test:coverage`)
- [x] Coverage thresholds met (80%)
- [x] Lint clean
- [x] Build passes
- [ ] Manual verification: load app while logged in, confirm videos persist after auth resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)